### PR TITLE
feat: add bean validation on RecipeDTO and all application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/src/main/java/com/masprog/controller/RecipeController.java
+++ b/src/main/java/com/masprog/controller/RecipeController.java
@@ -4,6 +4,7 @@ import com.masprog.dto.RecipeDTO;
 import com.masprog.dto.RecipeResponseDTO;
 import com.masprog.model.Recipe;
 import com.masprog.service.RecipeService;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,7 +23,7 @@ public class RecipeController {
     }
 
     @PostMapping
-    public ResponseEntity<RecipeResponseDTO> createRecipe(@RequestBody RecipeDTO recipeDTO){
+    public ResponseEntity<RecipeResponseDTO> createRecipe( @RequestBody @Valid RecipeDTO recipeDTO){
        RecipeResponseDTO created = recipeService.createRecipe(recipeDTO);
        return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }

--- a/src/main/java/com/masprog/dto/RecipeDTO.java
+++ b/src/main/java/com/masprog/dto/RecipeDTO.java
@@ -1,15 +1,29 @@
 package com.masprog.dto;
 
 import com.masprog.model.RecipeOrigin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
 
 public class RecipeDTO {
+
+    @NotNull(message = "Origin is required")
     private RecipeOrigin origin;
+
+    @NotNull(message = "Value is required")
+    @Positive(message = "Value must be positive")
     private BigDecimal value;
+
+    @NotBlank(message = "Destination is required")
     private String destination;
+
+    @NotNull(message = "Received date is required")
+    @PastOrPresent(message = "Received date must be in the past or present")
     private LocalDate receivedDate;
 
     public RecipeDTO(){}

--- a/src/main/java/com/masprog/exceptions/MethodArgumentNotValidException.java
+++ b/src/main/java/com/masprog/exceptions/MethodArgumentNotValidException.java
@@ -1,0 +1,16 @@
+package com.masprog.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class MethodArgumentNotValidException extends RuntimeException {
+    public MethodArgumentNotValidException() {
+        super("Validation failed");
+    }
+
+    public MethodArgumentNotValidException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/masprog/exceptions/handler/CustomEntityResponseHandler.java
+++ b/src/main/java/com/masprog/exceptions/handler/CustomEntityResponseHandler.java
@@ -3,8 +3,15 @@ package com.masprog.exceptions.handler;
 import com.masprog.exceptions.ExceptionResponse;
 import com.masprog.exceptions.RequiredObjectIsNullException;
 import com.masprog.exceptions.ResourceNotFoundException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,30 +19,37 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @ControllerAdvice
 @RestController
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class CustomEntityResponseHandler extends ResponseEntityExceptionHandler {
+    public CustomEntityResponseHandler() {
+        System.out.println("CustomEntityResponseHandler initialized");
+    }
 
-   @ExceptionHandler(Exception.class)
-   public final ResponseEntity<ExceptionResponse> handleAllException(Exception ex, WebRequest request) {
-       ExceptionResponse response = new ExceptionResponse(
-               new Date(),
-               ex.getMessage(),
-               request.getDescription(false));
+    @ExceptionHandler(Exception.class)
+    public final ResponseEntity<ExceptionResponse> handleAllException(Exception ex, WebRequest request) {
+        ExceptionResponse response = new ExceptionResponse(
+                new Date(),
+                ex.getMessage(),
+                request.getDescription(false));
 
-       return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
-   }
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 
-   @ExceptionHandler(ResourceNotFoundException.class)
-   public final ResponseEntity<ExceptionResponse> handleNotFoundException(Exception ex, WebRequest request) {
-       ExceptionResponse response = new ExceptionResponse(
-               new Date(),
-               ex.getMessage(),
-               request.getDescription(false));
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public final ResponseEntity<ExceptionResponse> handleNotFoundException(Exception ex, WebRequest request) {
+        ExceptionResponse response = new ExceptionResponse(
+                new Date(),
+                ex.getMessage(),
+                request.getDescription(false));
 
-       return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
-   }
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
 
     @ExceptionHandler(RequiredObjectIsNullException.class)
     public final ResponseEntity<ExceptionResponse> handleBadRequestException(Exception ex, WebRequest request) {
@@ -46,4 +60,53 @@ public class CustomEntityResponseHandler extends ResponseEntityExceptionHandler 
 
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public final ResponseEntity<ExceptionResponse> handleDataIntegrityViolationException(
+            DataIntegrityViolationException ex, WebRequest request) {
+        ExceptionResponse response = new ExceptionResponse(
+                new Date(),
+                "Invalid data provided: " + ex.getMostSpecificCause().getMessage(),
+                request.getDescription(false));
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    //@Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            org.springframework.http.HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error -> {
+            errors.put(error.getField(), error.getDefaultMessage());
+        });
+
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", new Date());
+        body.put("status", status.value());
+        body.put("error", HttpStatus.valueOf(status.value()).getReasonPhrase());
+        body.put("path", request.getDescription(false).replace("uri=", ""));
+        body.put("message", "Validation failed");
+
+        Map<String, String> fieldErrors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                fieldErrors.put(error.getField(), error.getDefaultMessage())
+        );
+        body.put("fieldErrors", fieldErrors);
+
+        return new ResponseEntity<>(body, headers, HttpStatus.BAD_REQUEST);
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
+server:
+  port: 8081
+  error:
+    include-message: always
+    include-binding-errors: always
 spring:
   application:
     name: api-person-control-financial


### PR DESCRIPTION
## ✨ Descrição

Esta Pull Request implementa validações no `RecipeDTO` para garantir que os campos obrigatórios sejam preenchidos corretamente e atendam às regras de negócio. As validações foram adicionadas para os seguintes campos:

- `origin` (ex.: SALARIO, BONUS): Não pode ser nulo (`@NotNull`).
- `value`: Não pode ser nulo (`@NotNull`) e deve ser positivo (`@Positive`).
- `destination`: Não pode ser nulo ou vazio (`@NotBlank`).
- `receivedDate`: Não pode ser nulo (`@NotNull`) e deve ser uma data no passado ou presente (`@PastOrPresent`).

### Mudanças Realizadas
- Adicionadas anotações de validação do Bean Validation (`@NotNull`, `@NotBlank`, `@Positive`, `@PastOrPresent`) no `RecipeDTO`.
- Configurado o controlador para usar `@Valid` no endpoint `POST /api/v1/recipes`, acionando a validação automática do DTO.
- Implementado tratamento de erros no `CustomEntityResponseHandler` para `MethodArgumentNotValidException`, retornando uma resposta personalizada com os detalhes dos erros de validação no formato `{field: message}`.
- Adicionado `@Order(Ordered.HIGHEST_PRECEDENCE)` ao `CustomEntityResponseHandler` para garantir prioridade sobre outros manipuladores.
- Configurado o `application.properties` com `spring.mvc.problemdetails.enabled=false` para desativar o formato `ProblemDetail` padrão do Spring Boot, garantindo que a resposta personalizada seja usada.
- Mantido o mapeamento de `RecipeDTO` para `Recipe` e `RecipeResponseDTO` usando o Dozer Mapper.

### Resultado
- As validações agora funcionam corretamente. Requisições inválidas (ex.: `{"origin": null, "value": -10, "destination": "", "receivedDate": null}`) retornam HTTP 400 com uma resposta detalhando os erros, como:
  ```json
  {
      "timestamp": "2025-07-19T17:59:06.500+00:00",
      "status": 400,
      "error": "Bad Request",
      "path": "/api/v1/recipes",
      "message": "Validation failed",
      "fieldErrors": {
          "destination": "Destination is required",
          "receivedDate": "Received date is required"
      }
  }


## 📦 Impacto
- **Camada de Apresentação**: Validações aplicadas no `RecipeDTO` no endpoint `POST /api/v1/recipes`.
- **Camada de Serviço**: Verificação de nulo no `RecipeDTO` antes do mapeamento para `Recipe`.
- **Camada de Persistência**: Garante que a entidade `Recipe` receba apenas dados válidos, evitando violações de constraints do banco (ex.: `@Column(nullable = false)`).
- **Camada de Exceções**: Tentativa de personalizar a resposta de erros de validação com `CustomEntityResponseHandler`.

## 🧪 Testes

- **Pendente**: Adicionar testes unitários/ integração com JUnit e REST Assured para validar o comportamento das validações e do tratamento de erros.

## 👤 Reviewer Sugerido
@Mauro-Manuel