### PR TITLE
Feature/get by id recipe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,18 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.2.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
+			<version>5.2.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
 			<version>${testcontainers.version}</version>

--- a/src/main/java/com/masprog/controller/RecipeController.java
+++ b/src/main/java/com/masprog/controller/RecipeController.java
@@ -34,4 +34,10 @@ public class RecipeController {
         Page<RecipeResponseDTO> recipes = recipeService.getAllRecipes(filter, pageable);
         return ResponseEntity.ok(recipes);
     }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RecipeResponseDTO> getRecipeById(@PathVariable Long id) {
+        RecipeResponseDTO recipe = recipeService.getRecipeById(id);
+        return ResponseEntity.ok(recipe);
+    }
 }

--- a/src/main/java/com/masprog/service/RecipeService.java
+++ b/src/main/java/com/masprog/service/RecipeService.java
@@ -4,6 +4,7 @@ import com.masprog.dto.RecipeDTO;
 import com.masprog.dto.RecipeFilterDTO;
 import com.masprog.dto.RecipeResponseDTO;
 import com.masprog.exceptions.RequiredObjectIsNullException;
+import com.masprog.exceptions.ResourceNotFoundException;
 import com.masprog.model.Recipe;
 import com.masprog.repository.RecipeRepository;
 import com.masprog.repository.RecipeSpecification;
@@ -46,4 +47,15 @@ public class RecipeService {
         return recipePage.map(recipe -> parseObject(recipe, RecipeResponseDTO.class));
 
     }
+
+    @Transactional(readOnly = true)
+    public RecipeResponseDTO getRecipeById(Long id) {
+        if (id == null) throw new RequiredObjectIsNullException();
+        logger.info("Retrieving Recipe with ID: {}", id);
+        Recipe recipe = recipeRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Recipe not found with ID: " + id));
+        return parseObject(recipe, RecipeResponseDTO.class);
+    }
+
+
 }

--- a/src/test/java/com/masprog/controller/RecipeControllerTest.java
+++ b/src/test/java/com/masprog/controller/RecipeControllerTest.java
@@ -218,4 +218,48 @@ class RecipeControllerTest extends AbstractIntegrationTest {
 //                .statusCode(HttpStatus.BAD_REQUEST.value())
 //                .body("message", equalTo("Invalid origin value"));
 //    }
+
+    @Test
+    void testGetRecipeByIdSuccess() {
+        // Arrange: Create test data
+        Recipe recipe = new Recipe();
+        recipe.setOrigin(RecipeOrigin.SALARIO);
+        recipe.setValue(new BigDecimal("100.00"));
+        recipe.setDestination("Banco BAI");
+        recipe.setReceivedDate(LocalDate.of(2025, 7, 19));
+        recipe = recipeRepository.save(recipe);
+
+        // Act & Assert
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/api/v1/recipes/" + recipe.getId())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("id", equalTo(recipe.getId().intValue()))
+                .body("origin", equalTo("SALARIO"))
+                .body("value", equalTo(100.00f))
+                .body("destination", equalTo("Banco BAI"))
+                .body("receivedDate", equalTo("2025-07-19"));
+    }
+
+    @Test
+    void testGetRecipeByIdNotFound() {
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/api/v1/recipes/999")
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body("message",equalTo("Recipe not found with ID: 999"));
+    }
+    @Test
+    void testGetRecipeByIdInvalidId() {
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/api/v1/recipes/invalid")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
 }

--- a/src/test/java/com/masprog/service/RecipeServiceTest.java
+++ b/src/test/java/com/masprog/service/RecipeServiceTest.java
@@ -3,6 +3,8 @@ package com.masprog.service;
 import com.masprog.dto.RecipeDTO;
 import com.masprog.dto.RecipeFilterDTO;
 import com.masprog.dto.RecipeResponseDTO;
+import com.masprog.exceptions.RequiredObjectIsNullException;
+import com.masprog.exceptions.ResourceNotFoundException;
 import com.masprog.model.Recipe;
 import com.masprog.model.RecipeOrigin;
 import com.masprog.repository.RecipeRepository;
@@ -10,6 +12,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
+import static com.masprog.mapper.ObjectMapper.parseObject;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -23,11 +26,13 @@ import org.springframework.data.jpa.domain.Specification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -156,6 +161,67 @@ public class RecipeServiceTest {
         assertEquals(1, result.getTotalElements());
         assertEquals(RecipeOrigin.SALARIO, result.getContent().get(0).getOrigin());
     }
+
+    @Test
+    void shouldReturnRecipeResponseDTO_whenGetRecipeByIdWithValidId() {
+        // Arrange
+        Long id = 1L;
+        Recipe recipe = new Recipe();
+        recipe.setId(id);
+        recipe.setOrigin(RecipeOrigin.SALARIO);
+        recipe.setValue(new BigDecimal("1000.00"));
+        recipe.setDestination("Banco BAI");
+        recipe.setReceivedDate(LocalDate.of(2025, 7, 1));
+        recipe.setCreatedAt(LocalDate.now());
+
+        RecipeResponseDTO responseDTO = new RecipeResponseDTO();
+        responseDTO.setId(id);
+        responseDTO.setOrigin(RecipeOrigin.SALARIO);
+        responseDTO.setValue(new BigDecimal("1000.00"));
+        responseDTO.setDestination("Banco BAI");
+        responseDTO.setReceivedDate(LocalDate.of(2025, 7, 1));
+        responseDTO.setCreatedAt(LocalDate.now());
+
+        when(recipeRepository.findById(id)).thenReturn(Optional.of(recipe));
+
+        // Mock do método estático parseObject
+        try (var mockedStatic = mockStatic(com.masprog.mapper.ObjectMapper.class)) {
+            mockedStatic.when(() -> parseObject(recipe, RecipeResponseDTO.class)).thenReturn(responseDTO);
+
+            // Act
+            RecipeResponseDTO result = recipeService.getRecipeById(id);
+
+            // Assert
+            assertNotNull(result);
+            assertEquals(id, result.getId());
+            assertEquals(recipe.getOrigin(), result.getOrigin());
+            assertEquals(recipe.getValue(), result.getValue());
+            assertEquals(recipe.getDestination(), result.getDestination());
+            assertEquals(recipe.getReceivedDate(), result.getReceivedDate());
+        }
+    }
+
+    @Test
+    void shouldThrowResourceNotFoundException_whenGetRecipeByIdWithNonExistentId() {
+        // Arrange
+        Long id = 999L;
+        when(recipeRepository.findById(id)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
+                () -> recipeService.getRecipeById(id));
+        assertEquals("Recipe not found with ID: " + id, exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentException_whenGetRecipeByIdWithNullId() {
+        // Act & Assert
+        RequiredObjectIsNullException exception = assertThrows(RequiredObjectIsNullException.class,
+                () -> recipeService.getRecipeById(null));
+        assertEquals("It is not allowed to persist a null object!", exception.getMessage());
+    }
+
+
 
 
 


### PR DESCRIPTION
## ✨ Descrição

Esta Pull Request adiciona a funcionalidade de busca de receita por ID através do endpoint `GET /api/v1/recipes/{id}`.  
A implementação permite recuperar uma receita específica com base no seu identificador, retornando um `RecipeResponseDTO` ou um erro **404** caso a receita não seja encontrada.  
A solução segue as práticas do projeto, reutilizando os DTOs existentes e garantindo cobertura de testes.

---

## 📦 Impacto

Impacta diretamente a entidade `Recipe` e adiciona:

- Endpoint para buscar uma receita por ID.
- Tratamento de erros para IDs inválidos ou não encontrados.
- Testes unitários e de integração para validar o comportamento.

---

## 🔄 Mudanças Realizadas

### Camada de Serviço

- Adicionado método `getRecipeById` em `RecipeService` para buscar receita por ID e mapear para `RecipeResponseDTO`.
- Implementada validação de ID nulo e tratamento de erro para receita não encontrada.

### Controlador

- Adicionado endpoint `GET /api/v1/recipes/{id}` em `RecipeController`.

### Exceções

- Criada exceção personalizada `ResourceNotFoundException` para erros 404.
- Adicionado manipulador global de exceções em `ResourceNotFoundException` para respostas consistentes.

### Testes

#### Unitários

- Adicionados testes em `RecipeServiceTest` para cenários de:
  - Sucesso
  - ID não encontrado
  - ID nulo

#### Integração

- Adicionados testes em `RecipeControllerTest` usando **RestAssured** para validar:
  - Busca bem-sucedida de receita
  - Erro 404 para ID inexistente
  - Erro 400 para ID inválido

---

## ✅ Checklist

- [x] Código segue as diretrizes de estilo do projeto.
- [x] Testes unitários e de integração cobrem os principais cenários.
- [x] Sem alterações que quebram endpoints existentes.
- [x] Documentação atualizada (esta descrição do PR).

---

## 🧪 Como Testar

1. Inicie a aplicação:

   ```bash
   mvn spring-boot:run

