### PR TITLE
Feature/update recipe

### DIFF
--- a/src/main/java/com/masprog/controller/RecipeController.java
+++ b/src/main/java/com/masprog/controller/RecipeController.java
@@ -40,4 +40,11 @@ public class RecipeController {
         RecipeResponseDTO recipe = recipeService.getRecipeById(id);
         return ResponseEntity.ok(recipe);
     }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<RecipeResponseDTO> updateRecipe(@PathVariable Long id,
+                                                          @Valid @RequestBody RecipeDTO recipeDTO) {
+        RecipeResponseDTO updatedRecipe = recipeService.updateRecipe(id, recipeDTO);
+        return new ResponseEntity<>(updatedRecipe, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/masprog/service/RecipeService.java
+++ b/src/main/java/com/masprog/service/RecipeService.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 import static com.masprog.mapper.ObjectMapper.parseObject;
 
 @Service
@@ -55,6 +57,33 @@ public class RecipeService {
         Recipe recipe = recipeRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Recipe not found with ID: " + id));
         return parseObject(recipe, RecipeResponseDTO.class);
+    }
+
+    @Transactional
+    public RecipeResponseDTO updateRecipe(Long id, RecipeDTO recipeDTO) {
+        if (id == null || recipeDTO == null) {
+            throw new RequiredObjectIsNullException("Recipe ID and DTO cannot be null");
+        }
+
+        logger.info("Updating recipe with ID: {}", id);
+
+
+        Recipe existingRecipe = recipeRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Recipe not found with ID: " + id));
+
+
+        Recipe updatedRecipe = parseObject(recipeDTO, Recipe.class);
+        updatedRecipe.setId(existingRecipe.getId());
+        updatedRecipe.setCreatedAt(existingRecipe.getCreatedAt());
+        updatedRecipe.setUpdatedAt(LocalDate.now());
+        updatedRecipe.setMonth(recipeDTO.getReceivedDate().getMonthValue());
+        updatedRecipe.setYear(recipeDTO.getReceivedDate().getYear());
+
+        // Save the updated recipe
+        Recipe savedRecipe = recipeRepository.save(updatedRecipe);
+
+        // Convert to response DTO and return
+        return parseObject(savedRecipe, RecipeResponseDTO.class);
     }
 
 

--- a/src/test/java/com/masprog/controller/RecipeControllerTest.java
+++ b/src/test/java/com/masprog/controller/RecipeControllerTest.java
@@ -88,7 +88,7 @@ class RecipeControllerTest extends AbstractIntegrationTest {
                 "origin": "SALARIO",
                 "value": 100.00,
                 "destination": "Banco BAI",
-                "receivedDate": "2025-07-21"
+                "receivedDate": "2025-08-22"
             }
             """;
 
@@ -262,4 +262,150 @@ class RecipeControllerTest extends AbstractIntegrationTest {
                 .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
+
+    @Test
+    void testUpdateRecipeWithValidIdAndData() {
+        // Arrange: Criar uma receita no banco
+        Recipe recipe = new Recipe();
+        recipe.setOrigin(RecipeOrigin.SALARIO);
+        recipe.setValue(new BigDecimal("1000.00"));
+        recipe.setDestination("Banco BAI");
+        recipe.setReceivedDate(LocalDate.of(2025, 7, 18));
+        recipe.setMonth(7);
+        recipe.setYear(2025);
+        recipe.setCreatedAt(LocalDate.of(2025, 7, 18));
+        recipe.setUpdatedAt(LocalDate.of(2025, 7, 18));
+        recipe = recipeRepository.save(recipe);
+
+        String validJson = """
+            {
+                "origin": "SALARIO",
+                "value": 5000.00,
+                "destination": "Banco BIC",
+                "receivedDate": "2025-07-19"
+            }
+            """;
+
+        // Act & Assert
+        given()
+                .contentType(ContentType.JSON)
+                .body(validJson)
+                .when()
+                .put("/api/v1/recipes/" + recipe.getId())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("id", equalTo(recipe.getId().intValue()))
+                .body("origin", equalTo("SALARIO"))
+                .body("value", equalTo(5000.00f))
+                .body("destination", equalTo("Banco BIC"))
+                .body("receivedDate", equalTo("2025-07-19"))
+                .body("month", equalTo(7))
+                .body("year", equalTo(2025))
+                .body("createdAt", equalTo(LocalDate.now().toString()))
+                .body("updatedAt", equalTo(LocalDate.now().toString()));
+    }
+    @Test
+    void testUpdateRecipeWithInvalidId() {
+        String validJson = """
+            {
+                "origin": "SALARIO",
+                "value": 5000.00,
+                "destination": "Banco BIC",
+                "receivedDate": "2025-07-19"
+            }
+            """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(validJson)
+                .when()
+                .put("/api/v1/recipes/999")
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body("message", equalTo("Recipe not found with ID: 999"));
+    }
+
+    @Test
+    void testUpdateRecipeWithInvalidData() {
+        // Arrange: Criar uma receita no banco
+        Recipe recipe = new Recipe();
+        recipe.setOrigin(RecipeOrigin.SALARIO);
+        recipe.setValue(new BigDecimal("1000.00"));
+        recipe.setDestination("Banco BAI");
+        recipe.setReceivedDate(LocalDate.of(2025, 7, 18));
+        recipe = recipeRepository.save(recipe);
+
+        String invalidJson = """
+            {
+                "origin": null,
+                "value": -10,
+                "destination": "",
+                "receivedDate": null
+            }
+            """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(invalidJson)
+                .when()
+                .put("/api/v1/recipes/" + recipe.getId())
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", equalTo("Validation failed"))
+                .body("fieldErrors.origin", equalTo("Origin is required"))
+                .body("fieldErrors.value", equalTo("Value must be positive"))
+                .body("fieldErrors.destination", equalTo("Destination is required"))
+                .body("fieldErrors.receivedDate", equalTo("Received date is required"));
+    }
+
+    @Test
+    void testUpdateRecipeWithFutureDate() {
+        // Arrange: Criar uma receita no banco
+        Recipe recipe = new Recipe();
+        recipe.setOrigin(RecipeOrigin.SALARIO);
+        recipe.setValue(new BigDecimal("1000.00"));
+        recipe.setDestination("Banco BAI");
+        recipe.setReceivedDate(LocalDate.of(2025, 7, 18));
+        recipe = recipeRepository.save(recipe);
+
+        String futureDateJson = """
+            {
+                "origin": "SALARIO",
+                "value": 5000.00,
+                "destination": "Banco BIC",
+                "receivedDate": "2025-08-22"
+            }
+            """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(futureDateJson)
+                .when()
+                .put("/api/v1/recipes/" + recipe.getId())
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", equalTo("Validation failed"))
+                .body("fieldErrors.receivedDate", equalTo("Received date must be in the past or present"));
+    }
+
+    @Test
+    void testUpdateRecipeWithInvalidIdFormat() {
+        String validJson = """
+            {
+                "origin": "SALARIO",
+                "value": 5000.00,
+                "destination": "Banco BIC",
+                "receivedDate": "2025-07-19"
+            }
+            """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(validJson)
+                .when()
+                .put("/api/v1/recipes/invalid")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
 }

--- a/src/test/java/com/masprog/service/RecipeServiceTest.java
+++ b/src/test/java/com/masprog/service/RecipeServiceTest.java
@@ -32,8 +32,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class RecipeServiceTest {
@@ -221,9 +220,86 @@ public class RecipeServiceTest {
         assertEquals("It is not allowed to persist a null object!", exception.getMessage());
     }
 
+    @Test
+    void shouldReturnRecipeResponseDTO_whenUpdateRecipeWithValidIdAndDTO() {
+        // Arrange
+        Long id = 1L;
+        RecipeDTO recipeDTO = new RecipeDTO();
+        recipeDTO.setOrigin(RecipeOrigin.SALARIO);
+        recipeDTO.setValue(new BigDecimal("5000.00"));
+        recipeDTO.setDestination("Test");
+        recipeDTO.setReceivedDate(LocalDate.now());
 
+        Recipe existingRecipe = new Recipe();
+        existingRecipe.setId(id);
+        existingRecipe.setOrigin(RecipeOrigin.SALARIO);
+        existingRecipe.setValue(new BigDecimal("1000.00"));
+        existingRecipe.setDestination("Old Destination");
+        existingRecipe.setReceivedDate(LocalDate.now().minusDays(1));
+        existingRecipe.setCreatedAt(LocalDate.now().minusDays(2));
 
+        RecipeResponseDTO responseDTO = new RecipeResponseDTO();
+        responseDTO.setId(id);
+        responseDTO.setOrigin(recipeDTO.getOrigin());
+        responseDTO.setValue(recipeDTO.getValue());
+        responseDTO.setDestination(recipeDTO.getDestination());
+        responseDTO.setReceivedDate(recipeDTO.getReceivedDate());
+        responseDTO.setMonth(recipeDTO.getReceivedDate().getMonthValue());
+        responseDTO.setYear(recipeDTO.getReceivedDate().getYear());
+        responseDTO.setCreatedAt(existingRecipe.getCreatedAt());
+        responseDTO.setUpdatedAt(LocalDate.now());
 
+        when(recipeRepository.findById(id)).thenReturn(Optional.of(existingRecipe));
+        when(recipeRepository.save(any(Recipe.class))).thenReturn(existingRecipe);
 
+        try (var mockedStatic = mockStatic(com.masprog.mapper.ObjectMapper.class)) {
+            mockedStatic.when(() -> parseObject(recipeDTO, Recipe.class)).thenReturn(existingRecipe);
+            mockedStatic.when(() -> parseObject(existingRecipe, RecipeResponseDTO.class)).thenReturn(responseDTO);
 
+            // Act
+            RecipeResponseDTO result = recipeService.updateRecipe(id, recipeDTO);
+
+            // Assert
+            assertNotNull(result);
+            assertEquals(id, result.getId());
+            assertEquals(recipeDTO.getOrigin(), result.getOrigin());
+            assertEquals(recipeDTO.getValue(), result.getValue());
+            assertEquals(recipeDTO.getDestination(), result.getDestination());
+            assertEquals(recipeDTO.getReceivedDate(), result.getReceivedDate());
+            assertEquals(recipeDTO.getReceivedDate().getMonthValue(), result.getMonth());
+            assertEquals(recipeDTO.getReceivedDate().getYear(), result.getYear());
+            assertEquals(existingRecipe.getCreatedAt(), result.getCreatedAt());
+            assertEquals(LocalDate.now(), result.getUpdatedAt());
+
+            verify(recipeRepository).findById(id);
+            verify(recipeRepository).save(any(Recipe.class));
+        }
+    }
+    @Test
+    void shouldThrowResourceNotFoundException_whenUpdateRecipeWithInvalidId() {
+        // Arrange
+        Long id = 999L;
+        RecipeDTO recipeDTO = new RecipeDTO();
+        recipeDTO.setOrigin(RecipeOrigin.SALARIO);
+        recipeDTO.setValue(new BigDecimal("5000.00"));
+        recipeDTO.setDestination("Test");
+        recipeDTO.setReceivedDate(LocalDate.now());
+
+        when(recipeRepository.findById(id)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResourceNotFoundException.class, () -> recipeService.updateRecipe(id, recipeDTO));
+        verify(recipeRepository).findById(id);
+        verify(recipeRepository, never()).save(any(Recipe.class));
+    }
+    @Test
+    void shouldThrowRequiredObjectIsNullException_whenUpdateRecipeWithNullDTO() {
+        // Arrange
+        Long id = 1L;
+
+        // Act & Assert
+        assertThrows(RequiredObjectIsNullException.class, () -> recipeService.updateRecipe(id, null));
+        verify(recipeRepository, never()).findById(anyLong());
+        verify(recipeRepository, never()).save(any(Recipe.class));
+    }
 }


### PR DESCRIPTION
## ✨ Descrição

Esta Pull Request adiciona a funcionalidade de **actualização de receitas** no sistema. O usuário poderá atualizar uma receita existente informando os seguintes dados:

- Origem da receita (ex: `SALARIO`, `BONUS`)
- Valor recebido
- Destino (conta onde foi aplicado)
- Data de recebimento

### 🔧 Principais mudanças

- Criado endpoint `PUT /api/v1/recipes/{id}` no `RecipeController`
- Implementado método `updateRecipe` no `RecipeService` para actualizar receitas
- Mantida a data de criação (`createdAt`) e actualizado o campo `updatedAt`
- Validações para ID e DTO nulos, com tratamento de exceções
- Testes automatizados unitários e de integração para a camada de serviço e controlador
- Persistência via JPA com atualização dos campos `month` e `year` derivados de `receivedDate`

## 📦 Impacto

Nenhum impacto direto em outras features.  
A funcionalidade de actualização é isolada e usa a mesma entidade `Recipe` e enum `RecipeOrigin` já existentes.

## 👤 Reviewer sugerido

@masprog2022 

## 🧪 Testes

- ✅ Atualização de receita com ID e dados válidos
- 🔍 Tentativa de atualização com ID inexistente (retorna **404**)
- 🚫 Tentativa de atualização com dados inválidos (retorna **400** com erros de validação)
- 🕒 Tentativa de atualização com data futura (retorna **400** com erro de validação)
- ❗ Tentativa de atualização com formato de ID inválido (retorna **400**)