### PR TITLE
Feature/delete recipe

### DIFF
--- a/src/main/java/com/masprog/controller/RecipeController.java
+++ b/src/main/java/com/masprog/controller/RecipeController.java
@@ -47,4 +47,10 @@ public class RecipeController {
         RecipeResponseDTO updatedRecipe = recipeService.updateRecipe(id, recipeDTO);
         return new ResponseEntity<>(updatedRecipe, HttpStatus.OK);
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteRecipe(@PathVariable Long id) {
+        recipeService.deleteRecipe(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/com/masprog/service/RecipeService.java
+++ b/src/main/java/com/masprog/service/RecipeService.java
@@ -79,12 +79,23 @@ public class RecipeService {
         updatedRecipe.setMonth(recipeDTO.getReceivedDate().getMonthValue());
         updatedRecipe.setYear(recipeDTO.getReceivedDate().getYear());
 
-        // Save the updated recipe
-        Recipe savedRecipe = recipeRepository.save(updatedRecipe);
 
-        // Convert to response DTO and return
+        Recipe savedRecipe = recipeRepository.save(updatedRecipe);
         return parseObject(savedRecipe, RecipeResponseDTO.class);
     }
+
+    @Transactional
+    public void deleteRecipe(Long id) {
+        if (id == null) {
+            throw new RequiredObjectIsNullException("Recipe ID cannot be null");
+        }
+        logger.info("Deleting recipe with ID: {}", id);
+        if (!recipeRepository.existsById(id)) {
+            throw new ResourceNotFoundException("Recipe not found with ID: " + id);
+        }
+        recipeRepository.deleteById(id);
+    }
+
 
 
 }

--- a/src/test/java/com/masprog/controller/RecipeControllerTest.java
+++ b/src/test/java/com/masprog/controller/RecipeControllerTest.java
@@ -349,4 +349,47 @@ class RecipeControllerTest extends AbstractIntegrationTest {
                     .statusCode(HttpStatus.BAD_REQUEST.value());
         }
     }
+
+    @Nested
+    class DeleteRecipeTests {
+
+        @Test
+        void shouldDeleteRecipeWithValidId() {
+            Recipe recipe = createRecipe(RecipeOrigin.SALARIO, VALID_VALUE, "Banco BAI", VALID_DATE);
+
+            given()
+                    .when()
+                    .delete("/api/v1/recipes/" + recipe.getId())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
+
+        @Test
+        void shouldReturn404WhenDeletingNonExistingRecipe() {
+            given()
+                    .when()
+                    .delete("/api/v1/recipes/999")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("message", equalTo("Recipe not found with ID: 999"));
+        }
+
+        @Test
+        void shouldReturn400WhenDeletingWithInvalidIdFormat() {
+            given()
+                    .when()
+                    .delete("/api/v1/recipes/invalid")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value());
+        }
+
+        @Test
+        void shouldReturn400WhenDeletingWithNullId() {
+            given()
+                    .when()
+                    .delete("/api/v1/recipes/")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value());
+        }
+    }
 }

--- a/src/test/java/com/masprog/service/RecipeServiceTest.java
+++ b/src/test/java/com/masprog/service/RecipeServiceTest.java
@@ -77,7 +77,6 @@ public class RecipeServiceTest {
         assertEquals(requestDTO.getDestination(), responseDTO.getDestination());
         assertEquals(requestDTO.getReceivedDate(), responseDTO.getReceivedDate());
     }
-
     @Test
     void shouldHaveViolation_whenValueIsNegative() {
         RecipeDTO dto = new RecipeDTO();
@@ -91,7 +90,6 @@ public class RecipeServiceTest {
         assertFalse(violations.isEmpty());
         violations.forEach(v -> System.out.println(v.getPropertyPath() + ": " + v.getMessage()));
     }
-
     @Test
     void shouldHaveViolation_whenValueIsNull() {
         RecipeDTO dto = new RecipeDTO();
@@ -104,7 +102,6 @@ public class RecipeServiceTest {
 
         assertFalse(violations.isEmpty());
     }
-
     @Test
     void shouldHaveViolation_whenReceivedDateIsInFuture() {
         RecipeDTO dto = new RecipeDTO();
@@ -117,7 +114,6 @@ public class RecipeServiceTest {
 
         assertFalse(violations.isEmpty());
     }
-
     @Test
     void shouldThrowRuntimeException_whenRepositoryFails() {
         RecipeDTO dto = new RecipeDTO();
@@ -135,9 +131,8 @@ public class RecipeServiceTest {
 
         assertEquals("Falha na base de dados", ex.getMessage());
     }
-
     @Test
-    void testGetAllRecipesWithFilter(){
+    void shouldReturnFilteredRecipesWhenUsingValidQueryParameters(){
         RecipeFilterDTO filter = new RecipeFilterDTO();
         filter.setOrigin(RecipeOrigin.SALARIO);
         Pageable pageable = PageRequest.of(0, 10);
@@ -160,7 +155,6 @@ public class RecipeServiceTest {
         assertEquals(1, result.getTotalElements());
         assertEquals(RecipeOrigin.SALARIO, result.getContent().get(0).getOrigin());
     }
-
     @Test
     void shouldReturnRecipeResponseDTO_whenGetRecipeByIdWithValidId() {
         // Arrange
@@ -199,7 +193,6 @@ public class RecipeServiceTest {
             assertEquals(recipe.getReceivedDate(), result.getReceivedDate());
         }
     }
-
     @Test
     void shouldThrowResourceNotFoundException_whenGetRecipeByIdWithNonExistentId() {
         // Arrange
@@ -211,7 +204,6 @@ public class RecipeServiceTest {
                 () -> recipeService.getRecipeById(id));
         assertEquals("Recipe not found with ID: " + id, exception.getMessage());
     }
-
     @Test
     void shouldThrowIllegalArgumentException_whenGetRecipeByIdWithNullId() {
         // Act & Assert
@@ -219,7 +211,6 @@ public class RecipeServiceTest {
                 () -> recipeService.getRecipeById(null));
         assertEquals("It is not allowed to persist a null object!", exception.getMessage());
     }
-
     @Test
     void shouldReturnRecipeResponseDTO_whenUpdateRecipeWithValidIdAndDTO() {
         // Arrange
@@ -301,5 +292,36 @@ public class RecipeServiceTest {
         assertThrows(RequiredObjectIsNullException.class, () -> recipeService.updateRecipe(id, null));
         verify(recipeRepository, never()).findById(anyLong());
         verify(recipeRepository, never()).save(any(Recipe.class));
+    }
+    @Test
+    void shouldDeleteRecipe_whenDeleteRecipeWithValidId() {
+        // Arrange
+        Long id = 1L;
+        when(recipeRepository.existsById(id)).thenReturn(true);
+
+        // Act
+        recipeService.deleteRecipe(id);
+
+        // Assert
+        verify(recipeRepository).existsById(id);
+        verify(recipeRepository).deleteById(id);
+    }
+    @Test
+    void shouldThrowResourceNotFoundException_whenDeleteRecipeWithInvalidId() {
+        // Arrange
+        Long id = 999L;
+        when(recipeRepository.existsById(id)).thenReturn(false);
+
+        // Act & Assert
+        assertThrows(ResourceNotFoundException.class, () -> recipeService.deleteRecipe(id));
+        verify(recipeRepository).existsById(id);
+        verify(recipeRepository, never()).deleteById(id);
+    }
+    @Test
+    void shouldThrowRequiredObjectIsNullException_whenDeleteRecipeWithNullId() {
+        // Act & Assert
+        assertThrows(RequiredObjectIsNullException.class, () -> recipeService.deleteRecipe(null));
+        verify(recipeRepository, never()).existsById(anyLong());
+        verify(recipeRepository, never()).deleteById(anyLong());
     }
 }


### PR DESCRIPTION
## ✨ Descrição

Esta Pull Request adiciona a funcionalidade de exclusão de receitas no sistema. O usuário poderá excluir uma receita existente informando o ID da receita.

As principais mudanças incluem:

- Criado endpoint `DELETE /api/v1/recipes/{id}` no `RecipeController`
- Implementado o método `deleteRecipe(Long id)` no `RecipeService` com as seguintes validações:
  - Lançamento de exceção `RequiredObjectIsNullException` se o ID for `null`
  - Lançamento de exceção `ResourceNotFoundException` se a receita não existir
- Persistência via `RecipeRepository` utilizando `deleteById`
- Validações para ID nulo ou inexistente, com tratamento adequado de exceções

## 📦 Impacto

Nenhum impacto direto em outras funcionalidades. A exclusão é uma operação isolada sobre a entidade `Recipe`, respeitando as regras de negócio e validações.

## 🧪 Testes

Foram adicionados testes **unitários** e **de integração** para garantir a robustez do comportamento da exclusão:

### Unitários (`RecipeServiceTest`):

- ✅ Exclusão bem-sucedida com ID válido
- ✅ Lançamento de `ResourceNotFoundException` ao tentar excluir uma receita inexistente
- ✅ Lançamento de `RequiredObjectIsNullException` ao tentar excluir com ID nulo

### Integração (`RecipeControllerTest`):

- ✅ Exclusão de receita com ID válido (`204 No Content`)
- ✅ Tentativa de exclusão com ID inexistente (`404 Not Found`)
- ✅ Tentativa de exclusão com formato de ID inválido (`400 Bad Request`)
- ✅ Tentativa de exclusão com ID ausente na URL (`404 Not Found`)

## 👤 Reviewer sugerido

@masprog2022 
